### PR TITLE
Check compiler exists points to the wrong compiler dir

### DIFF
--- a/bin/check.ml
+++ b/bin/check.ml
@@ -74,8 +74,8 @@ let check_exists file () =
   else
     Some (File_not_found file)
 
-let check_compiler_exists kind =
-  check_exists @@ Printf.sprintf "%s/%s" (string_of_kind kind) !Env.compiler
+let check_compiler_exists kind () =
+  (check_exists @@ Printf.sprintf "%s/%s" !(compiler_dir_of_kind kind) !Env.compiler) ()
 
 let run_compiler ?dir ?(error=false) ?(output=[]) {name; content} () =
   let filename =


### PR DESCRIPTION
## Issue

When the group directory is nested with another folder (for example in this case `min-caml`)

```
└── group
    └── min-caml
        ├── LICENSE
        ├── Makefile
        ├── OCamlMakefile
        ├── ...
```

There is a convenient helper `find_compiler_directory` that automatically sets `Dir.group_compiler` to the correct root. However, in the init function

```ocaml
let init () =
  exec
    [change_directory Dir.tmp;
     clone Group;
     find_compiler_directory Group;
     build Group;
     check_compiler_exists Group]
  |> Option.to_list
```

It seems like `check_compiler_exists Group` is accessing the wrong directory and fails the `init` entirely.
When I checked the implementation, 

```ocaml
let check_compiler_exists kind = 
  check_exists @@ Printf.sprintf "%s/%s" (string_of_kind kind) !Env.compiler
```

`check_compiler_exists` calls `string_of_kind` instead of `compiler_dir_of_kind`. However, even though I changed it to `compiler_dir_of_kind`, it defaults to `""` and fails the `init` function.

## Solution

Originally, `check_compiler_exists kind` accesses `Dir.group_compiler` then generates a thunk.
I changed it to a thunk that accesses `Dir.group_compiler` instead.

## Impact

This should not affect previous behavior if the source is at the root level.
However, it should be fixed for those who have nested directories.