### PR TITLE
Infer Build System or Specify it in Command Line Argument

### DIFF
--- a/bin/assignment.ml
+++ b/bin/assignment.ml
@@ -44,21 +44,9 @@ let commit_file_of_kind = function
   | Group -> "group_COMMIT"
   | Individual -> "my_COMMIT"
 
-let build_of_kind = function
-  | Group -> Env.group_build
-  | Individual -> Env.individual_build
-
-let compiler_path_of_kind = function
-  | Group -> Env.group_compiler_path
-  | Individual -> Env.individual_compiler_path
-
-let compiler_exec_of_kind = function
-  | Group -> Env.group_exec
-  | Individual -> Env.individual_exec
-
-let compiler_dir_of_kind = function
-  | Group -> Config.Dir.group_compiler
-  | Individual -> Config.Dir.individual_compiler
+let compiler_param_of param = function
+  | Group -> param.group
+  | Individual -> param.individual
 
 let subject_of n =
   if n <= 0 then

--- a/bin/assignment.ml
+++ b/bin/assignment.ml
@@ -44,6 +44,18 @@ let commit_file_of_kind = function
   | Group -> "group_COMMIT"
   | Individual -> "my_COMMIT"
 
+let build_of_kind = function
+  | Group -> Env.group_build
+  | Individual -> Env.individual_build
+
+let compiler_path_of_kind = function
+  | Group -> Env.group_compiler_path
+  | Individual -> Env.individual_compiler_path
+
+let compiler_exec_of_kind = function
+  | Group -> Env.group_exec
+  | Individual -> Env.individual_exec
+
 let compiler_dir_of_kind = function
   | Group -> Config.Dir.group_compiler
   | Individual -> Config.Dir.individual_compiler

--- a/bin/check.ml
+++ b/bin/check.ml
@@ -56,27 +56,30 @@ let infer_build_system kind () =
         |> Filename.dirname
         |> Option.some
   in
-  let update_if_empty string_ref with_value = if !string_ref = "" then string_ref := with_value in
+  let update_param param with_value =
+    let ref = compiler_param_of param kind in
+    if !ref = param.init then ref := with_value in
 
   let base_dir = string_of_kind kind in
   let open Option in
-  (* hint file,  build command,      compiler exe file path,    exec command *)
-  ["dune",       "dune build",       "_build/default/main.exe", "dune exec mincaml --";
-   "to_x86",     "./to_x86 && make", "min-caml",                "./min-caml";
-   "Cargo.toml", "cargo build",      "",                        "cargo run -- -i"]
-  |> List.find_map_default (fun (hint, cmd, path, exec) ->
+  (* hint file,  build command,      compiler exe file path,    exec command,                             input mode *)
+  ["dune",       "dune build",       "_build/default/main.exe", "dune exec mincaml --",                   MinCaml;
+   "to_x86",     "./to_x86 && make", "min-caml",                "./min-caml",                             MinCaml;
+   "Cargo.toml", "cargo build",      "",                        "cargo run -- -i ./tests/pervasives.mli", Explicit]
+  |> List.find_map_default (fun (hint, build, compiler_path, exec, arg_style) ->
        let* dir = find_shallowest_dir_in base_dir hint in
        Log.debug "found the submission using %s@." hint;
-       compiler_dir_of_kind kind := dir;
-       update_if_empty (build_of_kind kind) cmd;
-       update_if_empty (compiler_path_of_kind kind) path;
-       update_if_empty (compiler_exec_of_kind kind) exec;
+       compiler_param_of Config.Dir.compiler kind := dir;
+       update_param Env.build build;
+       update_param Env.compiler_path compiler_path;
+       update_param Env.exec exec;
+       update_param Env.arg_style arg_style;
        return None) (Some (Compiler_directory_not_found kind))
 
 let build kind () =
   Log.normal "Building the %s compiler...@.@." (string_of_kind kind);
-  let dir = !(compiler_dir_of_kind kind) in
-  if 0 = Command.run ~filename:"build" "cd %s; %s" dir !(build_of_kind kind) then
+  let dir = !(compiler_param_of Config.Dir.compiler kind) in
+  if 0 = Command.run ~filename:"build" "cd %s; %s" dir !(compiler_param_of Env.build kind) then
     None
   else
     (Command.mv [dir^"/build.err"; dir^"/build.out"] Dir.orig_working;
@@ -89,7 +92,7 @@ let check_exists file () =
     Some (File_not_found file)
 
 let check_compiler_exists kind () =
-  let compiler_path = !(compiler_path_of_kind kind) in
+  let compiler_path = !(compiler_param_of Env.compiler_path kind) in
   if compiler_path = "" then
     None
   else
@@ -102,23 +105,28 @@ let run_compiler ?dir ?(error=false) ?(output=[]) kind {name; content} () =
     | Some dir -> dir ^ "/"  ^ name
   in
   Log.debug "[Check.run_compiler] filename: %s@." filename;
-  if Sys.file_exists filename then
-    invalid_arg "%s" __FUNCTION__
+  if Sys.file_exists filename then invalid_arg "%s" __FUNCTION__;
+  let real_filename = filename ^ ".ml" in
+  let cout = open_out_bin real_filename in
+  let content =
+    match content with
+    | File input -> IO.CPS.open_in input BatPervasives.input_all
+    | Raw s -> s
+  in
+  output_string cout content;
+  close_out cout;
+  let path_of =
+    let base = Sys.getcwd () in
+    fun filename -> base ^ "/" ^ filename in
+  let filename = path_of filename in
+  let arg = match !(compiler_param_of Env.arg_style kind) with
+    | MinCaml -> filename
+    | Explicit -> Format.sprintf "-i %s -o %s.s" (path_of real_filename) filename in
+  let r = Command.run ~filename "cd %s; %s %s" !(compiler_param_of Config.Dir.compiler kind) !(compiler_param_of Env.exec kind) arg in
+  if 0 = r || error then
+    None
   else
-    let cout = open_out_bin (filename ^ ".ml") in
-    let content =
-      match content with
-      | File input -> IO.CPS.open_in input BatPervasives.input_all
-      | Raw s -> s
-    in
-    output_string cout content;
-    close_out cout;
-    let filename = Sys.getcwd () ^ "/" ^ filename in
-    let r = Command.run ~filename "cd %s; %s %s" !(compiler_dir_of_kind kind) !(compiler_exec_of_kind kind) filename in
-    if 0 = r || error then
-      None
-    else
-      Some (Test_failed output)
+    Some (Test_failed output)
 
 let find_file filename =
   !Env.files @ Array.to_list @@ Sys.readdir "."

--- a/bin/check.ml
+++ b/bin/check.ml
@@ -44,7 +44,7 @@ let clone kind () =
         Some Clone_failed
 
 (* Must be called after clone_* *)
-let find_compiler_directory kind () =
+let infer_build_system kind () =
   let find_shallowest_dir_in dir name =
     match Unix.open_and_read_lines (Printf.sprintf "find %s -name %s" dir name) with
     | [] -> None

--- a/bin/check.ml
+++ b/bin/check.ml
@@ -63,7 +63,7 @@ let infer_build_system kind () =
   (* hint file,  build command,      compiler exe file path,      exec command *)
   ["to_x86",     "./to_x86 && make", "mincaml",                   "mincaml";
    "dune",       "dune build",       "./_build/default/main.exe", "dune exec mincaml --";
-   "Cargo.toml", "cargo build",      "",                          "cargo run --"]
+   "Cargo.toml", "cargo build",      "",                          "cargo run -- -i"]
   |> List.find_map_default (fun (hint, cmd, path, exec) ->
        let* dir = find_shallowest_dir_in base_dir hint in
        compiler_dir_of_kind kind := dir;

--- a/bin/command_line.ml
+++ b/bin/command_line.ml
@@ -6,13 +6,34 @@ let name = "compiler_jikken"
 let print_version () =
   Printf.printf "%s %s\n" name Const.version
 
+module MyArgs = struct
+  let default_build = ref None
+  let group_build = ref None
+  let individual_build = ref None
+  let default_compiler_path = ref None
+  let group_compiler_path = ref None
+  let individual_compiler_path = ref None
+  let default_exec = ref None
+  let group_exec = ref None
+  let individual_exec = ref None
+end
+
+let arg_set_opt_string ref = Arg.String (fun str -> ref := Some str)
+
 let options =
   ["-f", Arg.Set Env.force, "";
    "-e", Arg.Clear Env.jp, "";
-   "--build", Arg.Set_string Env.build, {|<command>  Use <command> to build min-caml instead of "./to_x86 && make"|};
-   "-b", Arg.Set_string Env.build, " The same as --build";
-   "--compiler-path", Arg.Set_string Env.compiler, {|<path-to-compiler>  Use <path-to-compiler> to run the compiler instead of "min-caml"|};
-   "-c", Arg.Set_string Env.compiler, " The same as --compiler-path";
+   "--build",                    arg_set_opt_string MyArgs.default_build,            "<command>  Use <command> to build compiler without inferring";
+   "--build-group",              arg_set_opt_string MyArgs.group_build,              "<command>  Similar to --build, but for group compiler";
+   "--build-individual",         arg_set_opt_string MyArgs.individual_build,         "<command>  Similar to --build, but for individual compiler";
+   "-b",                         arg_set_opt_string MyArgs.default_build,            " The same as --build";
+   "--compiler-path",            arg_set_opt_string MyArgs.default_compiler_path,    "<path>  Check if the compiler exist in <path> after build";
+   "--compiler-path-group",      arg_set_opt_string MyArgs.group_compiler_path,      "<path>  Similar to --compiler-path, but for group compiler";
+   "--compiler-path-individual", arg_set_opt_string MyArgs.individual_compiler_path, "<path>  Similar to --compiler-path, but for individual compiler";
+   "-c",                         arg_set_opt_string MyArgs.default_compiler_path,    " The same as --compiler-path";
+   "--exec",                     arg_set_opt_string MyArgs.default_exec,             "<command>  Use <command> to run the compiler without inferring";
+   "--exec-group",               arg_set_opt_string MyArgs.group_exec,               "<command>  Similar to --exec, but for group compiler";
+   "--exec-individual",          arg_set_opt_string MyArgs.individual_exec,          "<command>  Similar to --exec, but for individual compiler";
    "-v", Arg.Unit (fun () -> print_version (); exit 0), " Output the version";
    "--silent", Arg.Unit (fun () -> Config.Log.mode := Silent), "";
    "--verbose", Arg.Unit (fun () -> Config.Log.mode := Verbose), "";
@@ -28,4 +49,16 @@ let set_file arg =
 
 let usage = Printf.sprintf "Usage: %s XX-YYYYYY <files>" name
 
-let parse () = Arg.parse (Arg.align options) set_file usage
+let parse () =
+  Arg.parse (Arg.align options) set_file usage;
+  let (||) x y =
+    match x with
+    | None -> y
+    | Some _ -> x in
+  let override_env ref option = Option.iter (fun value -> ref := value) option in
+  override_env Env.group_build (!MyArgs.group_build || !MyArgs.default_build);
+  override_env Env.individual_build (!MyArgs.individual_build || !MyArgs.default_build);
+  override_env Env.group_compiler_path (!MyArgs.group_compiler_path || !MyArgs.default_compiler_path);
+  override_env Env.individual_compiler_path (!MyArgs.individual_compiler_path || !MyArgs.default_compiler_path);
+  override_env Env.group_exec (!MyArgs.group_exec || !MyArgs.default_exec);
+  override_env Env.individual_exec (!MyArgs.individual_exec || !MyArgs.default_exec);

--- a/bin/config.ml
+++ b/bin/config.ml
@@ -6,26 +6,45 @@ module Const = struct
   let report_exts = ["txt"; "md"; "pdf"]
 end
 
+type 't compiler_param = {
+  init: 't;
+  group: 't ref;
+  individual: 't ref;
+}
+let init_compiler_param init = {
+  init;
+  group = ref init;
+  individual = ref init;
+}
+
+module ArgStyle = struct
+  type t = MinCaml | Explicit
+
+  let arg_style_of_string = function
+    | "mincaml" (* supports typo *)
+    | "min-caml" -> MinCaml
+    | "explicit" -> Explicit
+    | _ -> invalid_arg "%s" __FUNCTION__
+end
+
 module Env = struct
   let no = ref 0
   let id = ref ""
   let force = ref false
   let jp = ref true
   let files : string list ref = ref []
-  let group_build = ref ""
-  let individual_build = ref ""
-  let group_compiler_path = ref ""
-  let individual_compiler_path = ref ""
-  let group_exec = ref ""
-  let individual_exec = ref ""
   let report_file = ref ""
+
+  let build = init_compiler_param ""
+  let compiler_path = init_compiler_param ""
+  let exec = init_compiler_param ""
+  let arg_style = init_compiler_param ArgStyle.MinCaml
 end
 
 module Dir = struct
   let orig_working = Sys.getcwd()
   let tmp = "_comp_tmp_" ^ Unix.string_of_time()
-  let group_compiler = ref ""
-  let individual_compiler = ref ""
+  let compiler = init_compiler_param ""
   let archive() = Printf.sprintf "%02d-%s" !Env.no !Env.id
 end
 

--- a/bin/config.ml
+++ b/bin/config.ml
@@ -12,8 +12,12 @@ module Env = struct
   let force = ref false
   let jp = ref true
   let files : string list ref = ref []
-  let build = ref "./to_x86 && make"
-  let compiler = ref "min-caml"
+  let group_build = ref ""
+  let individual_build = ref ""
+  let group_compiler_path = ref ""
+  let individual_compiler_path = ref ""
+  let group_exec = ref ""
+  let individual_exec = ref ""
   let report_file = ref ""
 end
 

--- a/bin/week01.ml
+++ b/bin/week01.ml
@@ -7,7 +7,7 @@ let init () =
   exec
     [change_directory Dir.tmp;
      clone Group;
-     find_compiler_directory Group;
+     infer_build_system Group;
      build Group;
      check_compiler_exists Group]
   |> Option.to_list

--- a/bin/week01.ml
+++ b/bin/week01.ml
@@ -34,7 +34,7 @@ let toi1 () =
       else
         Some (Output_not_found ("*." ^ ext))
     in
-    match run_compiler ~dir ~output file () with
+    match run_compiler ~dir ~output Group file () with
     | None -> map check exts ()
     | Some e -> [e]
   in
@@ -48,7 +48,7 @@ let toi2 () =
   in
   let check (file, line) () =
     let output = output_of file in
-    match run_compiler ~dir ~error:true ~output file () with
+    match run_compiler ~dir ~error:true ~output Group file () with
     | None ->
         let file_out = Printf.sprintf "%s/%s.out" dir file.name in
         let file_err = Printf.sprintf "%s/%s.err" dir file.name in
@@ -76,7 +76,7 @@ let toi3 () =
   in
   let check file () =
     let output = output_of file in
-    match run_compiler ~dir ~output file () with
+    match run_compiler ~dir ~output Group file () with
     | None ->
         let filename = Printf.sprintf "%s/%s.s" dir file.name in
         if Sys.file_exists filename then

--- a/bin/week02.ml
+++ b/bin/week02.ml
@@ -34,7 +34,7 @@ let toi2 () =
       else
         Some (Output_not_found ("*." ^ ext))
     in
-    match run_compiler ~dir ~output file () with
+    match run_compiler ~dir ~output Group file () with
     | None -> map check exts ()
     | Some e -> [e]
   in

--- a/bin/week02.ml
+++ b/bin/week02.ml
@@ -7,7 +7,7 @@ let init () =
   exec
     [change_directory Dir.tmp;
      clone Group;
-     find_compiler_directory Group;
+     infer_build_system Group;
      build Group;
      check_compiler_exists Group]
   |> Option.to_list

--- a/bin/week03.ml
+++ b/bin/week03.ml
@@ -10,7 +10,7 @@ let toi2 () =
     [check_exists_commit_file Individual;
      change_directory Dir.tmp;
      clone Individual;
-     find_compiler_directory Individual;
+     infer_build_system Individual;
      build Individual;
      check_compiler_exists Individual]
   |> Option.to_list

--- a/bin/week04.ml
+++ b/bin/week04.ml
@@ -7,7 +7,7 @@ let init () =
   exec
     [change_directory Dir.tmp;
      clone Group;
-     find_compiler_directory Group;
+     infer_build_system Group;
      build Group;
      check_compiler_exists Group]
   |> Option.to_list

--- a/bin/week04.ml
+++ b/bin/week04.ml
@@ -32,7 +32,7 @@ let toi23 name files () =
       else
         Some (Output_not_found ("*." ^ ext))
     in
-    match run_compiler ~dir ~output file () with
+    match run_compiler ~dir ~output Group file () with
     | None ->
         begin match map check exts () with
         | [] ->

--- a/bin/week06.ml
+++ b/bin/week06.ml
@@ -26,7 +26,7 @@ let toi4 () =
   in
   let check file () =
     let output = output_of file in
-    match run_compiler ~dir ~output file () with
+    match run_compiler ~dir ~output Group file () with
     | None ->
         let filename = Printf.sprintf "%s/%s.s" dir file.name in
         if Sys.file_exists filename then

--- a/bin/week06.ml
+++ b/bin/week06.ml
@@ -7,7 +7,7 @@ let init () =
   exec
     [change_directory Dir.tmp;
      clone Group;
-     find_compiler_directory Group;
+     infer_build_system Group;
      build Group;
      check_compiler_exists Group]
   |> Option.to_list

--- a/bin/week07.ml
+++ b/bin/week07.ml
@@ -12,7 +12,7 @@ let toi2 () =
     [check_exists_commit_file kind;
      change_directory Dir.tmp;
      clone kind;
-     find_compiler_directory kind;
+     infer_build_system kind;
      build kind;
      check_compiler_exists kind]
   |> Option.to_list

--- a/bin/week08.ml
+++ b/bin/week08.ml
@@ -12,7 +12,7 @@ let toi1 () =
     [check_exists_commit_file kind;
      change_directory Dir.tmp;
      clone kind;
-     find_compiler_directory kind;
+     infer_build_system kind;
      build kind;
      check_compiler_exists kind]
   |> Option.to_list

--- a/bin/week09.ml
+++ b/bin/week09.ml
@@ -12,7 +12,7 @@ let toi1 () =
     [check_exists_commit_file kind;
      change_directory Dir.tmp;
      clone kind;
-     find_compiler_directory kind;
+     infer_build_system kind;
      build kind;
      check_compiler_exists kind]
   |> Option.to_list

--- a/bin/week10.ml
+++ b/bin/week10.ml
@@ -12,7 +12,7 @@ let toi1 () =
     [check_exists_commit_file kind;
      change_directory Dir.tmp;
      clone kind;
-     find_compiler_directory kind;
+     infer_build_system kind;
      build kind;
      check_compiler_exists kind]
   |> Option.to_list

--- a/bin/week12.ml
+++ b/bin/week12.ml
@@ -12,7 +12,7 @@ let toi1 () =
     [check_exists_commit_file kind;
      change_directory Dir.tmp;
      clone kind;
-     find_compiler_directory kind;
+     infer_build_system kind;
      build kind;
      check_compiler_exists kind]
   |> Option.to_list


### PR DESCRIPTION
オリジナル版でビルド用ディレクトリを発見していた `find_compiler_directory` の実装をもとに，オリジナル版・dune版・Rust版をファイル構造から察してビルドに関係する変数（コンパイラのビルドコマンド・コンパイラの実行ファイルの相対パス・実行時のコマンド）を与えるようにしました．
例として，Rust版を使っていて`./tests/pervasives.mli`を移動させた場合は，`print_int`のインターフェース定義を含むファイルを`--exec "cargo run -- -i mlRuntime.mli -i"`のように引数を与えることになります．
また，これらをすべてコマンドライン引数で上書きできるようにしました．

ビルドの種別（グループ課題/個人課題）への対応が中途半端だったのをすべて`kind`を引数に取るように変更しました．これにより，一つの提出にグループ課題と個人課題が両方あり，両方でコマンドライン引数による上書きが必要な状況に対応できます（テストケースを見る限りそのような回は存在しませんが）．
コマンドライン引数にもその種別を反映させました．suffixがついていないものはデフォルトの値を指定します．

#2 で導入された`--compiler-path`並びに`-c`は，`--compiler-path-group`および`--compiler-path-individual`が指定されなかった場合のデフォルトの値として働くほか，コンパイラの元となった版から計算したコンパイラの実行ファイルの相対パスの値を上書きするという位置づけになりました．この値はコンパイル後にそこにファイルがあるかどうかのチェックのためだけに使われ，実行時には`--exec`系で指定されたコマンドを使うようになりました．察する機能がうまくいっていない場合はこの両方を指定する必要があるということです．

この変更は #3 と独立です．
